### PR TITLE
Support auto discovery in Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,15 @@
       "Pepijnolivier\\Bittrex\\": "src/"
     }
   },
-  "minimum-stability": "dev"
+  "minimum-stability": "dev",
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Pepijnolivier\\Bittrex\\BittrexServiceProvider"
+      ],
+      "aliases": {
+        "Bittrex": "Pepijnolivier\\Bittrex\\Bittrex"
+      }
+    }
+  }
 }

--- a/src/BittrexServiceProvider.php
+++ b/src/BittrexServiceProvider.php
@@ -24,6 +24,8 @@ class BittrexServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->mergeConfigFrom(__DIR__.'/../config/bittrex.php', 'bittrex');
+
         $this->app->singleton('bittrex', function () {
             return new BittrexManager;
         });


### PR DESCRIPTION
Supports auto discovery now and no error is thrown if the user didn't publish the bittrex config.